### PR TITLE
Use labels to query for monitored apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ update interval of 1 second and two marathon hosts.
 Updater is reachable at port 7676.
 
 ```
-docker run -d -p 7676:7676 bobrik/marathoner-updater:1.0 \
+docker run -d -p 7676:7676 bobrik/marathoner-updater:1.10 \
   -m http://marathon1:8080,http://marathon2:8080 -i 1
 ```
 
@@ -88,7 +88,7 @@ two updaters and publishes apps on `127.0.0.1`.
 Notice that you need to run listener with `--net=host`.
 
 ```
-docker run -d --net=host bobrik/marathoner-listener:1.0 \
+docker run -d --net=host bobrik/marathoner-listener:1.10 \
   -u marathoner-updater1:7676,marathoner-updater2:7676 -b 127.0.0.1
 ```
 
@@ -98,7 +98,7 @@ The following command runs marathoner logger with
 specified updater and logs state changes to stdout:
 
 ```
-docker run --rm bobrik/marathoner-logger:1.2 -u marathoner-updater1:7676
+docker run --rm bobrik/marathoner-logger:1.10 -u marathoner-updater1:7676
 ```
 
 ### Exposing apps
@@ -124,6 +124,8 @@ could help you with building containers. Just run:
 
 ## Version history
 
+* 1.10
+  * Updater: only asking for apps with marathoner enabled
 * 1.9
   * Updater: 20 second timeout for getting state from marathon
 * 1.8

--- a/marathon.go
+++ b/marathon.go
@@ -109,7 +109,7 @@ func (m Marathon) State() (State, error) {
 // fetchApps fetches apps from random alive marathon server
 func (m Marathon) fetchApps() (*http.Response, error) {
 	for _, i := range m.rand.Perm(len(m.endpoints)) {
-		resp, err := m.client.Get(m.endpoints[i] + "/v2/apps?embed=apps.tasks")
+		resp, err := m.client.Get(m.endpoints[i] + "/v2/apps?embed=apps.tasks&label=marathoner_haproxy_enabled")
 		if err != nil {
 			log.Println("error fetching marathon apps from " + m.endpoints[i] + ", " + err.Error())
 			continue


### PR DESCRIPTION
No improvement in CPU utilization for Marathon instances:

![image](https://cloud.githubusercontent.com/assets/89186/7877807/355018a6-05e8-11e5-8b23-10ef2ed691f7.png)

Small improvement for marathoner (load was negligible anyway):

![image](https://cloud.githubusercontent.com/assets/89186/7877830/7843b8a2-05e8-11e5-99dd-da789449880d.png)

![image](https://cloud.githubusercontent.com/assets/89186/7877833/881c4c58-05e8-11e5-9ed2-7915332cdd95.png)
